### PR TITLE
run ansible-playbook with docker in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,23 @@
 language: python
 python: "2.7"
 
-sudo: false
+dist: trusty
+sudo: required
 
-addons:
-  apt:
-    packages:
-    - python-pip
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y python-pip
+  - sudo apt-get install -y apt-transport-https ca-certificates
+  - sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+  - echo 'deb https://apt.dockerproject.org/repo ubuntu-trusty main' | sudo tee /etc/apt/sources.list.d/docker.list
+  - sudo apt-get update
+  - sudo apt-get purge -y lxc-docker
+  - sudo apt-get install -o Dpkg::Options::="--force-confdef" -y docker-engine
+  - docker version
+  - docker pull ubuntu:latest
+  - docker run --privileged=true --name test -di ubuntu
+  - docker exec test apt-get update
+  - docker exec test apt-get install -y python ca-certificates
 
 install:
   - pip install ansible
@@ -18,6 +29,7 @@ install:
 script:
   - ansible-playbook -i localhost, --syntax-check tests/test.yml
   - ansible-lint tests/test.yml
+  - ansible-playbook -i test, tests/test.yml
 
 notifications:
   email: false

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,10 +1,9 @@
 ---
-- hosts: all
-  become: yes
+- hosts: test
+  connection: docker
+  remote_user: root # workaround to ansible 2.0.2 gives -u None
   roles:
     - role: ansible-pbuilder-role
-      pbuilder_base: raspbian
-      pbuilder_dist: jessie
-      pbuilder_arch: armhf
+      pbuilder_base: ubuntu
+      pbuilder_dist: trusty
       pbuilder_config: /home/vagrant/.pbuilderrc
-      pbuilder_update: yes


### PR DESCRIPTION
This pull request add test to run ansible-playbook with docker connection on Travis CI.
